### PR TITLE
Improve statistic aa1 to implement 1 (Fix invalid contribution type statistic)

### DIFF
--- a/src/reducer/database/osm/models.ts
+++ b/src/reducer/database/osm/models.ts
@@ -1034,7 +1034,7 @@ abstract class StatisticSO extends BaseSO {
           [self.year]
         )[0] as Share,
         pullRequest: SOAssembler.database.exec(
-          StatisticSO.statements.issueContributionsOfYear,
+          StatisticSO.statements.pullRequestContributionsOfYear,
           [self.year]
         )[0] as Share,
         pullRequestReview: SOAssembler.database.exec(


### PR DESCRIPTION
There were a issues that the share calculation was invalid and issue
were always the same value like pullRequests. This was because of a
wrongly set object statements.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Documentation (non-breaking change which adds documentation)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- Currently the contribution type share total is wrong. #79
- Currently the contribution type of pullRequests and issues are always equal. #80


**What is the new behavior (if this is a feature change)?**
- Now the contribution type share calculation is fixed. #79
- Now the contribution types of pullRequest and issues are set to their own values. #80


**Other information**:
- 🐍 

