### PR TITLE
Improve organization statements aa1 to master (Bugfix: invalid organizations on generateTalks())

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snek-intel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "http://snek.at",
   "license": "EUPL-1.2",
   "main": "lib/index.js",

--- a/src/reducer/database/osm/statements/organization.ts
+++ b/src/reducer/database/osm/statements/organization.ts
@@ -46,7 +46,7 @@ SELECT id,
         FROM   platformhasorganization pho
                INNER JOIN platform p
                        ON pho.platformId = p.id
-        WHERE  pho.organizationId = 1) AS platformName
+        WHERE  pho.organizationId = o.id) AS platformName
 FROM   organization o
 `;
 //#endregion


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Documentation (non-breaking change which adds documentation)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- Currently the talk generation is invalid if GitHub and GitLab are connected. Closes #83 


**What is the new behavior (if this is a feature change)?**
- Now talk generation is processing only GitHub organizations. Therefore there is no querying error on GitLab organisations. #83


**Other information**:
- 🐍 

